### PR TITLE
Fix $APACHE_DOC_ROOT

### DIFF
--- a/start
+++ b/start
@@ -8,7 +8,7 @@ echo "date.timezone = $PHP_TIMEZONE" > /usr/local/etc/php/conf.d/timezone.ini
 # Configure Apache Document Root
 mkdir -p $APACHE_DOC_ROOT
 chown www-data:www-data $APACHE_DOC_ROOT
-sed -i "s|DocumentRoot /var/www/html|DocumentRoot $APACHE_DOC_ROOT|" /etc/apache2/apache2.conf
+sed -i "s|DocumentRoot /var/www/html|DocumentRoot $APACHE_DOC_ROOT|" /etc/apache2/sites-available/000-default.conf
 echo "<Directory $APACHE_DOC_ROOT>" > /etc/apache2/conf-available/document-root-directory.conf
 echo "	AllowOverride All" >> /etc/apache2/conf-available/document-root-directory.conf
 echo "	Require all granted" >> /etc/apache2/conf-available/document-root-directory.conf


### PR DESCRIPTION
The debian default config of apache2 doesn't have the DocumentRoot-Directive directly in the apache2.conf ... so changing the APACHE_DOC_ROOT from the default `/var/www/html` didn't work.
